### PR TITLE
Update GitHub links with new username

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 - 2021 Nik Brandt
+Copyright (c) 2017 - 2021 Nikolas Brandt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 - 2020 Gymnophoria
+Copyright (c) 2017 - 2021 Nik Brandt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Eh, we're going back to using an MIT license, I feel weird having contributors b
 
 PRs, issues, complaints, whatever, all welcome. You can also complain in the support server above.
 
-Gymnophoria
+Nik Brandt

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -5,7 +5,7 @@ First off, thank you for having an interest in translating Arthur into your lang
 I have plans to make the translation process easier with a website, but I realize that it may be a while until that happens and I might as well have proper documentation of the current translation process. **Please read this whole document if you would like to translate Arthur.** It isn't too long (especially in comparison to the actual translation :eyes:), and I'd like to ensure that the translation process is as smooth as possible, both for you and me.
 
 Thanks again!
- \- Gymnophoria
+ \- Nik Brandt
 
 ## Setup
 
@@ -72,7 +72,7 @@ Please follow steps 1 and 2. I'll happily setup a file for you, though (meaning 
 
 - Save often! I've already seen two people lose a fair bit of progress because of computer restarts/accidentally closing windows/etc. If your editor doesn't auto save, consider saving after every command or some other often interval to avoid this frustration.
 
-- Please ask questions about anything if you're confused! Join the [support server](https://discord.gg/2SDdyF7) if you haven't already to ask questions, or if you prefer message me at Gymnophoria#8146.
+- Please ask questions about anything if you're confused! Join the [support server](https://discord.gg/2SDdyF7) if you haven't already to ask questions, or if you prefer message me at Gymno#4741.
 
  ## Finished translating?
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -13,7 +13,7 @@ Please follow steps 1 and 2. I'll happily setup a file for you, though (meaning 
 
 1. Get a good code editor. You could do this all in TextEdit or Notepad, but it'll be harder and more time consuming. I highly recommend [Visual Studio Code](https://code.visualstudio.com/Download), but any editor that supports JSON syntax highlighting and code indentation will do. A big plus if it'll catch JSON errors for you.
 
-2. Open up Arthur's [en-US locale file](https://github.com/Gymnophoria/Arthur/blob/master/locales/en-US%20English%2C%20US.json) for reference. If you'd like to view it locally instead of in your browser, click the "Raw" button and then right click -> `Save as...`.
+2. Open up Arthur's [en-US locale file](https://github.com/nikbrandt/Arthur/blob/master/locales/en-US%20English%2C%20US.json) for reference. If you'd like to view it locally instead of in your browser, click the "Raw" button and then right click -> `Save as...`.
 
 3. Make a JSON file for your language and open it in your editor.
 
@@ -66,7 +66,7 @@ Please follow steps 1 and 2. I'll happily setup a file for you, though (meaning 
 ## Tips and Tricks
 
  - Try to reference the en-US file that I had you open in the setup if you're confused about JSON syntax.
-   - To see a working example translation, look at the [Dutch locale file](https://github.com/Gymnophoria/Arthur/blob/master/locales/nl%20Nederlands.json). It's no longer complete (as I've added many commands/translation features since it was completed), but it is still relevant.
+   - To see a working example translation, look at the [Dutch locale file](https://github.com/nikbrandt/Arthur/blob/master/locales/nl%20Nederlands.json). It's no longer complete (as I've added many commands/translation features since it was completed), but it is still relevant.
 
 - The en-US file is huge. Take your time, you can translate in steps. If you only feel like translating part of it, that's also fine; a partial translation is better than nothing, and I'll gladly add it to Arthur.
 

--- a/commands/apis/strawpoll.js
+++ b/commands/apis/strawpoll.js
@@ -110,7 +110,7 @@ exports.run = async (message, args, suffix) => {
 			method: 'POST',
 			uri: 'https://www.strawpoll.me/api/v2/polls',
 			headers: {
-				'User-Agent': 'Arthur Discord Bot (https://github.com/Gymnophoria/Arthur)'
+				'User-Agent': 'Arthur Discord Bot (https://github.com/nikbrandt/Arthur)'
 			},
 			body: { title, options, multi, dupcheck, captcha },
 			json: true

--- a/commands/help.js
+++ b/commands/help.js
@@ -50,7 +50,7 @@ exports.run = async (message, args, suffix, client, perms, prefix) => {
 				name: message.__('arthur_help'),
 				icon_url: 'https://cdn.discordapp.com/attachments/219218693928910848/361405047608705025/arthur_but_hot.png'
 			},
-			description: `[${message.__('large_embed.invite')}](${invite}) | [GitHub](https://github.com/Gymnophoria/Arthur) | [${message.__('large_embed.support_server')}](${client.config.info.guildLink}) | [Trello](https://trello.com/b/wt7ptHpC/arthur) | [${message.__('large_embed.tos')}](https://docs.google.com/document/d/1kbGlTbG-SDcO5AiN2mWbhJNr7AyOZi26n3Nt9duI95w/edit?usp=sharing)\n${message.__('large_embed.description')}`,
+			description: `[${message.__('large_embed.invite')}](${invite}) | [GitHub](https://github.com/nikbrandt/Arthur) | [${message.__('large_embed.support_server')}](${client.config.info.guildLink}) | [Trello](https://trello.com/b/wt7ptHpC/arthur) | [${message.__('large_embed.tos')}](https://docs.google.com/document/d/1kbGlTbG-SDcO5AiN2mWbhJNr7AyOZi26n3Nt9duI95w/edit?usp=sharing)\n${message.__('large_embed.description')}`,
 			fields,
 			footer: {
 				text: message.__('large_embed.footer', { prefix })

--- a/commands/info.js
+++ b/commands/info.js
@@ -17,7 +17,7 @@ exports.run = async (message, args, asdf, client) => {
 		fields: [
 			{
 				name: message.__('author'),
-				value: 'Gymnophoria#8146',
+				value: 'Gymno#4741',
 				inline: true
 			},
 			{

--- a/commands/info.js
+++ b/commands/info.js
@@ -12,7 +12,7 @@ exports.run = async (message, args, asdf, client) => {
 			name: message.__('title'),
 			icon_url: 'https://cdn.discordapp.com/attachments/219218693928910848/361405047608705025/arthur_but_hot.png'
 		},
-		description: `${message.__('description')}\n [${i18n.get('commands.help.large_embed.invite', message)}](${invite}) | [GitHub](https://github.com/Gymnophoria/Arthur) | [${i18n.get('commands.help.large_embed.support_server', message)}](${client.config.info.guildLink}) | [Trello](https://trello.com/b/wt7ptHpC/arthur) | [${i18n.get('commands.help.large_embed.tos', message)}](https://docs.google.com/document/d/1kbGlTbG-SDcO5AiN2mWbhJNr7AyOZi26n3Nt9duI95w/edit?usp=sharing)`,
+		description: `${message.__('description')}\n [${i18n.get('commands.help.large_embed.invite', message)}](${invite}) | [GitHub](https://github.com/nikbrandt/Arthur) | [${i18n.get('commands.help.large_embed.support_server', message)}](${client.config.info.guildLink}) | [Trello](https://trello.com/b/wt7ptHpC/arthur) | [${i18n.get('commands.help.large_embed.tos', message)}](https://docs.google.com/document/d/1kbGlTbG-SDcO5AiN2mWbhJNr7AyOZi26n3Nt9duI95w/edit?usp=sharing)`,
 		color: 0x00c140,
 		fields: [
 			{

--- a/commands/misc/mp3.js
+++ b/commands/misc/mp3.js
@@ -57,7 +57,7 @@ async function finish(stream, title, length, message, msg, client, thumbnail, ur
 				url: 'https://file.io',
 				method: 'POST',
 				headers: {
-					'User-Agent': 'Arthur Discord Bot (github.com/Gymnophoria/Arthur)'
+					'User-Agent': 'Arthur Discord Bot (github.com/nikbrandt/Arthur)'
 				},
 				formData: {
 					file: {

--- a/locales/en-US English, US.json
+++ b/locales/en-US English, US.json
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"authors": [
-		  "Gymnophoria#8146",
+		  "Gymno#4741",
 		  "Technocoder#9418",
 		  "GlitchMasta47",
 		  "JRoy"
@@ -582,7 +582,7 @@
 				"name": "Server Language",
 				"description": "Set the language of Arthur for your server. User settings overwrite.",
 				"usage": "[locale]",
-				"help": "Set the language of Arthur for your server. User settings will overwrite if present. To get a list of languages, use the `@@languages` command. If a language is incomplete, it will use text from English for missing translations. To help translate Arthur, ask Gymnophoria in the support server (available in the info or help commands)."
+				"help": "Set the language of Arthur for your server. User settings will overwrite if present. To get a list of languages, use the `@@languages` command. If a language is incomplete, it will use text from English for missing translations. To help translate Arthur, ask Gymno#4741 in the support server (available in the info or help commands)."
 
 			},
 			"current_language": "This server's language is $locale",
@@ -1058,7 +1058,7 @@
 				"invite": "Invite",
 				"support_server": "Support Server",
 				"tos": "TOS",
-				"description": "Made by Gymnophoria#8146\nWhen using commands, <> indicates a required argument and [] indicates an optional requirement. (Do not actually type these symbols.)",
+				"description": "Made by Gymno#4741\nWhen using commands, <> indicates a required argument and [] indicates an optional requirement. (Do not actually type these symbols.)",
 				"footer": "Type $prefix@@help <command> for a detailed description of the command"
 			},
 			"check_dms": "Check your DM's :mailbox_with_mail:",

--- a/locales/nl Nederlands.json
+++ b/locales/nl Nederlands.json
@@ -273,7 +273,7 @@
 		},
 		"guildlanguage": {
 			"current_language": "De taal hier is gezet naar $locale",
-			"list": "Talen die momenteel worden ondersteund:\n$locales\nAls je wil helpen met het vertalen van Arthur, neem dan contact op met Gymnophoria in de support server.",
+			"list": "Talen die momenteel worden ondersteund:\n$locales\nAls je wil helpen met het vertalen van Arthur, neem dan contact op met Gymno#4741 in de support server.",
 			"invalid_locale": "Ongeldige invoer. Kies uit deze dinkies: $locales. hoofdletter-GEVOELIG.",
 			"locale_set": "Server taal ingesteld."
 		},
@@ -458,7 +458,7 @@
 				"invite": "Uitnodiging",
 				"support_server": "Support Server",
 				"tos": "TOS",
-				"description": "Gemaakt door Gymnophoria#8146\nWanneer je een command gebruikt, <> staat vor een verplicht onderdeel en [] staat voor een optioneel onderdeel. (Je moet deze symbolen niet daadwerkelijk typen.)",
+				"description": "Gemaakt door Gymno#4741\nWanneer je een command gebruikt, <> staat vor een verplicht onderdeel en [] staat voor een optioneel onderdeel. (Je moet deze symbolen niet daadwerkelijk typen.)",
 				"footer": "Type $prefix\u200bhelp <command> voor een gedetaileerde omschrijving van de command"
 			},
 			"check_dms": "Kijk in je privéberichten :mailbox_with_mail:",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"author": "Gymnophoria",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Gymnophoria/Arthur.git"
+		"url": "https://github.com/nikbrandt/Arthur.git"
 	},
 	"license": "MIT",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"arthur",
 		"marvin"
 	],
-	"author": "Gymnophoria",
+	"author": "Nik Brandt",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/nikbrandt/Arthur.git"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"arthur",
 		"marvin"
 	],
-	"author": "Nik Brandt",
+	"author": "Nikolas Brandt",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/nikbrandt/Arthur.git"

--- a/struct/Music.js
+++ b/struct/Music.js
@@ -532,7 +532,7 @@ const Music = {
 						meta: {
 							title: `${message._('sound_effect')} - ${id}`,
 							queueName: `${message._('sound_effect')} - ${id}`,
-							url: 'https://github.com/Gymnophoria/Arthur',
+							url: 'https://github.com/nikbrandt/Arthur',
 							length: soundEffectLengths[id.toLowerCase()]
 						},
 						ms: 30000


### PR DESCRIPTION
Currently, the old links will redirect to the new and correct links, however that is not guaranteed to happen forever. Changing the links to match ahead of time will prevent any potential issues in the future.